### PR TITLE
Add 'auto truncating' feature.

### DIFF
--- a/AllMiniLmL6V2Sharp.Tests/AllMiniLmL6V2.Test.cs
+++ b/AllMiniLmL6V2Sharp.Tests/AllMiniLmL6V2.Test.cs
@@ -1,3 +1,5 @@
+using Microsoft.ML.OnnxRuntime;
+
 namespace AllMiniLmL6V2Sharp.Tests
 {
     public class AllMiniLmL6V2Tests
@@ -17,6 +19,24 @@ namespace AllMiniLmL6V2Sharp.Tests
         {
             var model = new AllMiniLmL6V2Embedder();
             string[] sentences = ["This is an example sentence", "Here is another"];
+            var embedding = model.GenerateEmbeddings(sentences);
+            Assert.NotNull(embedding);
+            Assert.NotEmpty(embedding);
+        }
+
+        [Fact]
+        public void LongContextTest()
+        {
+            var model = new AllMiniLmL6V2Embedder();
+            string[] sentences = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac mauris nulla. Nullam rutrum, urna eu elementum cursus, eros risus sollicitudin magna, maximus eleifend mi lorem et tellus. Fusce lacus tellus, consectetur ac turpis in, ultricies consequat felis. Aliquam imperdiet tristique ante at consequat. Fusce sed efficitur ipsum. Aliquam erat volutpat. In molestie sapien non porttitor iaculis. Nunc pretium mauris nisl, eu luctus augue volutpat dapibus. Ut rutrum nec ante vitae commodo. Praesent facilisis eget leo eget congue.\r\n\r\nUt luctus lorem ut finibus sollicitudin. Morbi nec elit vel lorem congue condimentum. Vivamus feugiat enim et sapien mollis, nec feugiat lacus pellentesque. Cras aliquet, nisi at imperdiet dictum, metus ex congue elit, sed semper est erat imperdiet leo. Curabitur consequat urna turpis, a sollicitudin justo eleifend ac. Nunc dignissim tincidunt erat vitae ullamcorper. Phasellus nulla urna, gravida ac neque et, rhoncus convallis lorem. Etiam id erat sit amet leo mollis viverra. Pellentesque efficitur pretium nunc.\r\n\r\nCurabitur eget est metus. Donec mollis, tortor eu finibus volutpat, odio ex scelerisque dui, id lobortis neque est ac dolor. Praesent bibendum ex vel ultricies varius. Nullam molestie massa vitae nunc faucibus, id pellentesque augue tincidunt. Morbi fermentum dolor quis gravida venenatis. Duis mattis in nisl eu fringilla. Proin vulputate dui vel ligula rhoncus lobortis.\r\n\r\n"];
+            Assert.Throws<OnnxRuntimeException>(() => model.GenerateEmbeddings(sentences));
+        }
+
+        [Fact]
+        public void TruncateTest()
+        {
+            var model = new AllMiniLmL6V2Embedder(truncate: true);
+            string[] sentences = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac mauris nulla. Nullam rutrum, urna eu elementum cursus, eros risus sollicitudin magna, maximus eleifend mi lorem et tellus. Fusce lacus tellus, consectetur ac turpis in, ultricies consequat felis. Aliquam imperdiet tristique ante at consequat. Fusce sed efficitur ipsum. Aliquam erat volutpat. In molestie sapien non porttitor iaculis. Nunc pretium mauris nisl, eu luctus augue volutpat dapibus. Ut rutrum nec ante vitae commodo. Praesent facilisis eget leo eget congue.\r\n\r\nUt luctus lorem ut finibus sollicitudin. Morbi nec elit vel lorem congue condimentum. Vivamus feugiat enim et sapien mollis, nec feugiat lacus pellentesque. Cras aliquet, nisi at imperdiet dictum, metus ex congue elit, sed semper est erat imperdiet leo. Curabitur consequat urna turpis, a sollicitudin justo eleifend ac. Nunc dignissim tincidunt erat vitae ullamcorper. Phasellus nulla urna, gravida ac neque et, rhoncus convallis lorem. Etiam id erat sit amet leo mollis viverra. Pellentesque efficitur pretium nunc.\r\n\r\nCurabitur eget est metus. Donec mollis, tortor eu finibus volutpat, odio ex scelerisque dui, id lobortis neque est ac dolor. Praesent bibendum ex vel ultricies varius. Nullam molestie massa vitae nunc faucibus, id pellentesque augue tincidunt. Morbi fermentum dolor quis gravida venenatis. Duis mattis in nisl eu fringilla. Proin vulputate dui vel ligula rhoncus lobortis.\r\n\r\n"];
             var embedding = model.GenerateEmbeddings(sentences);
             Assert.NotNull(embedding);
             Assert.NotEmpty(embedding);

--- a/AllMiniLmL6V2Sharp/AllMiniLmL6V2Embedder.cs
+++ b/AllMiniLmL6V2Sharp/AllMiniLmL6V2Embedder.cs
@@ -14,10 +14,18 @@ namespace AllMiniLmL6V2Sharp
     {
         private readonly ITokenizer _tokenizer;
         private readonly string _modelPath;
-        public AllMiniLmL6V2Embedder(string modelPath = "./model/model.onnx", ITokenizer? tokenizer = null)
+        private readonly bool _truncate;
+        /// <summary>
+        /// Initializes the AllMiniLmL6v2 Embedder
+        /// </summary>
+        /// <param name="modelPath">Path to the embedding onnx model.</param>
+        /// <param name="tokenizer">Optional custom tokenizer function.</param>
+        /// <param name="truncate">If true, automatically truncates tokens to 512 tokens.</param>
+        public AllMiniLmL6V2Embedder(string modelPath = "./model/model.onnx", ITokenizer? tokenizer = null, bool truncate = false)
         {
             _tokenizer = tokenizer ?? new BertTokenizer("./model/vocab.txt");
             _modelPath = modelPath;
+            _truncate = truncate;
         }
 
         /// <summary>
@@ -29,6 +37,11 @@ namespace AllMiniLmL6V2Sharp
         {
             // Tokenize Input
             IEnumerable<Token> tokens = _tokenizer.Tokenize(sentence);
+            if(_truncate && tokens.Count() > 512)
+            {
+                tokens = tokens.Take(512);
+            }
+
             IEnumerable<EncodedToken> encodedTokens = _tokenizer.Encode(tokens.Count(), sentence);
 
             // Compute Token Embeddings
@@ -86,6 +99,11 @@ namespace AllMiniLmL6V2Sharp
             foreach (var sentence in sentences)
             {
                 IEnumerable<Token> tokens = _tokenizer.Tokenize(sentence);
+
+                if(_truncate && tokens.Count() > 512)
+                {
+                    tokens = tokens.Take(512);
+                }
 
                 allTokens = allTokens.Append(tokens);
             }

--- a/AllMiniLmL6V2Sharp/Tokenizer/BertTokenizer.cs
+++ b/AllMiniLmL6V2Sharp/Tokenizer/BertTokenizer.cs
@@ -52,6 +52,11 @@ namespace AllMiniLmL6V2Sharp.Tokenizer
         {
             IEnumerable<Token> tokens = Tokenize(text);
 
+            if(tokens.Count() > sequenceLength)
+            {
+                tokens = tokens.Take(sequenceLength);
+            }
+
             IEnumerable<long> padding = Enumerable.Repeat(0L, sequenceLength - tokens.Count());
             return tokens
                 .Select(token => new EncodedToken { InputIds = token.VocabularyIndex, TokenTypeIds = token.SegmentIndex, AttentionMask = 1L })


### PR DESCRIPTION
- If truncate is true, truncate to 512 tokens.
- Add tests
- Fix issue with bert tokenizer where a maxSequence smaller than the tokenized sentence breaks encoding.
fixes #3 