### PR TITLE
Include minilm v6 in nuget

### DIFF
--- a/AllMiniLmL6V2Sharp.Tests/AllMiniLmL6V2.Test.cs
+++ b/AllMiniLmL6V2Sharp.Tests/AllMiniLmL6V2.Test.cs
@@ -41,5 +41,59 @@ namespace AllMiniLmL6V2Sharp.Tests
             Assert.NotNull(embedding);
             Assert.NotEmpty(embedding);
         }
+
+        [Fact]
+        public void MultipleSameTest()
+        {
+            var model = new AllMiniLmL6V2Embedder();
+            string sentence = "Hello World!";
+            string[] sentences = [sentence, sentence, sentence, sentence];
+            var embedding = model.GenerateEmbedding(sentence);
+            var embeddings = model.GenerateEmbeddings(sentences);
+            Assert.NotNull(embedding);
+            Assert.NotEmpty(embedding);
+            Assert.NotNull(embeddings);
+            Assert.NotEmpty(embeddings);
+            Assert.Equal(sentences.Length, embeddings.Count());
+
+            // Make sure all embeddings are the same.
+            Assert.True(embeddings.All(e => e.SequenceEqual(embeddings.First())));
+            Assert.True(embeddings.All(e => e.Zip(embedding).All(v => v.First == v.Second))); 
+            
+            foreach (var batchEmbedding in embeddings)
+            {
+                Assert.True(batchEmbedding.SequenceEqual(embedding),
+                    "Single embedding does not match a batch embedding");
+            }
+        }
+
+        [Fact]
+        public void MultipleSamev2Test()
+        {
+            var model = new AllMiniLmL6V2Embedder();
+            string sentence = "This is an example sentence";
+            string[] sentences = ["not it", sentence, "another", sentence];
+            var embedding = model.GenerateEmbedding(sentence);
+            var embeddings = model.GenerateEmbeddings(sentences);
+            Assert.NotNull(embedding);
+            Assert.NotEmpty(embedding);
+            Assert.NotNull(embeddings);
+            Assert.NotEmpty(embeddings);
+            Assert.Equal(sentences.Length, embeddings.Count());
+
+
+            for (int i = 0; i < sentences.Length; i++)
+            {
+                var batch = embeddings.ElementAt(i);
+                if(i == 0 || i == 2)
+                {
+                    Assert.False(batch.SequenceEqual(embedding));
+                }
+                else
+                {
+                    Assert.True(batch.SequenceEqual(embedding));
+                }
+            }
+        }
     }
 }

--- a/AllMiniLmL6V2Sharp.Tests/AllMiniLmL6V2.Test.cs
+++ b/AllMiniLmL6V2Sharp.Tests/AllMiniLmL6V2.Test.cs
@@ -35,7 +35,7 @@ namespace AllMiniLmL6V2Sharp.Tests
         [Fact]
         public void TruncateTest()
         {
-            var model = new AllMiniLmL6V2Embedder(truncate: true);
+            using var model = new AllMiniLmL6V2Embedder(truncate: true);
             string[] sentences = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac mauris nulla. Nullam rutrum, urna eu elementum cursus, eros risus sollicitudin magna, maximus eleifend mi lorem et tellus. Fusce lacus tellus, consectetur ac turpis in, ultricies consequat felis. Aliquam imperdiet tristique ante at consequat. Fusce sed efficitur ipsum. Aliquam erat volutpat. In molestie sapien non porttitor iaculis. Nunc pretium mauris nisl, eu luctus augue volutpat dapibus. Ut rutrum nec ante vitae commodo. Praesent facilisis eget leo eget congue.\r\n\r\nUt luctus lorem ut finibus sollicitudin. Morbi nec elit vel lorem congue condimentum. Vivamus feugiat enim et sapien mollis, nec feugiat lacus pellentesque. Cras aliquet, nisi at imperdiet dictum, metus ex congue elit, sed semper est erat imperdiet leo. Curabitur consequat urna turpis, a sollicitudin justo eleifend ac. Nunc dignissim tincidunt erat vitae ullamcorper. Phasellus nulla urna, gravida ac neque et, rhoncus convallis lorem. Etiam id erat sit amet leo mollis viverra. Pellentesque efficitur pretium nunc.\r\n\r\nCurabitur eget est metus. Donec mollis, tortor eu finibus volutpat, odio ex scelerisque dui, id lobortis neque est ac dolor. Praesent bibendum ex vel ultricies varius. Nullam molestie massa vitae nunc faucibus, id pellentesque augue tincidunt. Morbi fermentum dolor quis gravida venenatis. Duis mattis in nisl eu fringilla. Proin vulputate dui vel ligula rhoncus lobortis.\r\n\r\n"];
             var embedding = model.GenerateEmbeddings(sentences);
             Assert.NotNull(embedding);
@@ -45,7 +45,7 @@ namespace AllMiniLmL6V2Sharp.Tests
         [Fact]
         public void MultipleSameTest()
         {
-            var model = new AllMiniLmL6V2Embedder();
+            using var model = new AllMiniLmL6V2Embedder();
             string sentence = "Hello World!";
             string[] sentences = [sentence, sentence, sentence, sentence];
             var embedding = model.GenerateEmbedding(sentence);
@@ -70,7 +70,7 @@ namespace AllMiniLmL6V2Sharp.Tests
         [Fact]
         public void MultipleSamev2Test()
         {
-            var model = new AllMiniLmL6V2Embedder();
+            using var model = new AllMiniLmL6V2Embedder();
             string sentence = "This is an example sentence";
             string[] sentences = ["not it", sentence, "another", sentence];
             var embedding = model.GenerateEmbedding(sentence);

--- a/AllMiniLmL6V2Sharp/AllMiniLmL6V2Sharp.csproj
+++ b/AllMiniLmL6V2Sharp/AllMiniLmL6V2Sharp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
     <Title>AllMiniLML6v2Sharp</Title>
-    <Version>0.0.1</Version>
+    <Version>0.0.3</Version>
     <Authors>ksanman</Authors>
     <Description>NET Standard 2.1 library to produces embeddings using C# Bert Tokenizer and Onnx All-Mini-LM-L6-v2 model.</Description>
     <Copyright>2023 Kody Sanchez</Copyright>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Includes tokenizer and onnx model.
 ## Nuget
 [AllMiniLML6v2Sharp](https://www.nuget.org/packages/AllMiniLmL6V2Sharp/)
 
+The Nuget does not include the onnx model or the vocab.txt. These can be found on Hugging Face (See tested models below).
+The Embedder looks for the default model.onnx and vocab.txt files in the ```.\models``` folder.
+You may use a custom onnx model or custom vocab as well.
+
 ### How to use
 - Single Sentence
 ```C#

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Includes tokenizer and onnx model.
 [AllMiniLML6v2Sharp](https://www.nuget.org/packages/AllMiniLmL6V2Sharp/)
 
 The Nuget does not include the onnx model or the vocab.txt. These can be found on Hugging Face (See tested models below).
-The Embedder looks for the default model.onnx and vocab.txt files in the ```.\models``` folder.
+The Embedder looks for the default model.onnx and vocab.txt files in the ```.\model``` folder.
 You may use a custom onnx model or custom vocab as well.
 
 ### How to use

--- a/README.md
+++ b/README.md
@@ -16,32 +16,32 @@ You may use a custom onnx model or custom vocab as well.
 - Single Sentence
 ```C#
 var sentence = "This is an example sentence";
-var embedder = new AllMiniLmL6V2Embedder();
+using var embedder = new AllMiniLmL6V2Embedder();
 var embedding = embedder.GenerateEmbedding(sentence);
 ```
 - Multiple Sentences
 ```C#
 string[] sentences = ["This is an example sentence", "Here is another"];
-var embedder = new AllMiniLmL6V2Embedder();
+using var embedder = new AllMiniLmL6V2Embedder();
 var embeddings = model.GenerateEmbeddings(sentences);
 ```
 - Custom All-MiniLM-L6-v2 onnx model
 ```C#
 var sentence = "This is an example sentence";
-var embedder = new AllMiniLmL6V2Embedder(modelPath: "path/to/model.onnx");
+using var embedder = new AllMiniLmL6V2Embedder(modelPath: "path/to/model.onnx");
 var embedding = embedder.GenerateEmbedding(sentence);
 ```
 - Custom vocab
 ```C#
 var sentence = "This is an example sentence";
 BertTokenizer tokenizer = new("path/to/vocab.txt");
-var embedder = new AllMiniLmL6V2Embedder(tokenizer: tokenizer);
+using var embedder = new AllMiniLmL6V2Embedder(tokenizer: tokenizer);
 var embedding = embedder.GenerateEmbedding(sentence);
 ```
 - Custom Tokenizer
 ```C#
 var sentence = "This is an example sentence";
 ITokenizer tokenizer = new CustomTokenizer();
-var embedder = new AllMiniLmL6V2Embedder(tokenizer: tokenizer);
+using var embedder = new AllMiniLmL6V2Embedder(tokenizer: tokenizer);
 var embedding = embedder.GenerateEmbedding(sentence);
 ```


### PR DESCRIPTION
fixes #6 

--- Changes ---
- Clarify ONNX model and vocab.txt not provided in Nuget package.
- Fix issue in GenerateEmbeddings where the correct attention mask is not being applied.
- Move session creation to the embedder constructor.
- Make embedder disposable. 